### PR TITLE
Add more configurations 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wezom/graphql-codegen-configurator",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Preset generator from GraphQL operations to Typescript code",
   "main": "lib/index.js",
   "module": "lib/index.mjs",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "access": "public"
   },
   "devDependencies": {
+    "@graphql-codegen/add": "^5.0.0",
     "@graphql-codegen/cli": "^5.0.0",
     "@graphql-codegen/plugin-helpers": "^5.0.1",
     "@graphql-codegen/typescript-operations": "^4.0.1",
@@ -59,6 +60,7 @@
     "eslint": "^8.46.0",
     "eslint-config-prettier": "^8.9.0",
     "glob": "^10.3.3",
+    "graphql-codegen-typescript-operation-types": "^2.0.1",
     "istanbul-badges-readme": "^1.8.5",
     "jsdom": "^22.1.0",
     "prettier": "^3.0.0",
@@ -68,8 +70,10 @@
     "vitest": "^0.34.1"
   },
   "peerDependencies": {
+    "@graphql-codegen/add": "^5.0.0",
     "@graphql-codegen/cli": "^5.0.0",
     "@graphql-codegen/plugin-helpers": "^5.0.1",
-    "@graphql-codegen/typescript-operations": "^4.0.1"
+    "@graphql-codegen/typescript-operations": "^4.0.1",
+    "graphql-codegen-typescript-operation-types": "^2.0.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 devDependencies:
+  '@graphql-codegen/add':
+    specifier: ^5.0.0
+    version: 5.0.0(graphql@16.8.0)
   '@graphql-codegen/cli':
     specifier: ^5.0.0
     version: 5.0.0(graphql@16.8.0)
@@ -41,6 +44,9 @@ devDependencies:
   glob:
     specifier: ^10.3.3
     version: 10.3.3
+  graphql-codegen-typescript-operation-types:
+    specifier: ^2.0.1
+    version: 2.0.1(graphql@16.8.0)
   istanbul-badges-readme:
     specifier: ^1.8.5
     version: 1.8.5
@@ -976,6 +982,16 @@ packages:
   /@eslint/js@8.46.0:
     resolution: {integrity: sha512-a8TLtmPi8xzPkCbp/OGFUo5yhRkHM2Ko9kOWP4znJr0WAhWyThaw3PnwX4vOTWOAMsV2uRt32PPDcEz63esSaA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dev: true
+
+  /@graphql-codegen/add@5.0.0(graphql@16.8.0):
+    resolution: {integrity: sha512-ynWDOsK2yxtFHwcJTB9shoSkUd7YXd6ZE57f0nk7W5cu/nAgxZZpEsnTPEpZB/Mjf14YRGe2uJHQ7AfElHjqUQ==}
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+    dependencies:
+      '@graphql-codegen/plugin-helpers': 5.0.1(graphql@16.8.0)
+      graphql: 16.8.0
+      tslib: 2.5.3
     dev: true
 
   /@graphql-codegen/cli@5.0.0(graphql@16.8.0):
@@ -3487,6 +3503,20 @@ packages:
 
   /graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
+    dev: true
+
+  /graphql-codegen-typescript-operation-types@2.0.1(graphql@16.8.0):
+    resolution: {integrity: sha512-uhF0+Qiy/PwJD5AURtzXGnB3hKBy+3MHR8M2p+UqAoAqYy/SJ1tEKgzDPijgWKItBNr3DWO6f+w2PF6B0DGEnA==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      graphql: ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+    dependencies:
+      '@graphql-codegen/plugin-helpers': 5.0.1(graphql@16.8.0)
+      '@graphql-codegen/typescript': 4.0.1(graphql@16.8.0)
+      graphql: 16.8.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
     dev: true
 
   /graphql-config@5.0.2(graphql@16.8.0):

--- a/src/SplitEnumsPatcher.ts
+++ b/src/SplitEnumsPatcher.ts
@@ -4,10 +4,12 @@ export class SplitEnumsPatcher {
 	protected readonly outputDir: string;
 	protected readonly enums: string = 'enums';
 	protected readonly operations: string;
+	protected readonly noRootIndexFile: boolean;
 
 	constructor(options: Options) {
 		this.outputDir = options.outputDir;
 		this.operations = options.fileNameForTypes || 'operations';
+		this.noRootIndexFile = options.noRootIndexFile || false;
 		this.afterAllFileWriteHook = this.afterAllFileWriteHook.bind(this);
 	}
 
@@ -30,7 +32,7 @@ export class SplitEnumsPatcher {
 		const content = this.readOperationsFile(operationsFile);
 		const enums = this.getEnums(content);
 
-		this.writeIndexFile(indexFile);
+		!this.noRootIndexFile && this.writeIndexFile(indexFile);
 		this.writeEnumsFile(enumsFile, enums);
 		this.rewriteOperationsFile(operationsFile, content, enums);
 	}
@@ -95,9 +97,10 @@ export class SplitEnumsPatcher {
 	}
 }
 
-interface Options {
+export interface Options {
 	outputDir: string;
 	fileNameForTypes?: string;
+	noRootIndexFile?: boolean;
 }
 
 interface Enum {

--- a/src/__specs__/SplitEnumsConfigurator.spec.ts
+++ b/src/__specs__/SplitEnumsConfigurator.spec.ts
@@ -15,10 +15,70 @@ describe('SplitEnumsConfigurator', () => {
 				schema: 'schema.graphql',
 				generates: {
 					'output/operations.ts': {
-						plugins: ['typescript', 'typescript-operations'],
+						plugins: [
+							'graphql-codegen-typescript-operation-types',
+							'typescript-operations',
+						],
 						config: {
 							declarationKind: 'interface',
 							onlyOperationTypes: true,
+							omitObjectTypes: true,
+							preResolveTypes: true,
+						},
+					},
+				},
+			})
+		);
+	});
+
+	it('should create codegen configuration with additional content', () => {
+		const configurator = new SplitEnumsConfigurator({
+			schema: 'schema.graphql',
+			outputDir: 'output',
+			addContent: [
+				{
+					content: 'content 1',
+				},
+				{
+					content: 'content 2',
+					placement: 'append',
+				},
+			],
+			pluginConfig: {
+				option1: 'test',
+				option2: true,
+				option3: { test: 2 },
+			},
+		});
+
+		const config = configurator.create();
+
+		expect(config).toEqual(
+			expect.objectContaining({
+				schema: 'schema.graphql',
+				generates: {
+					'output/operations.ts': {
+						plugins: [
+							'graphql-codegen-typescript-operation-types',
+							'typescript-operations',
+							{
+								add: { content: 'content 1' },
+							},
+							{
+								add: {
+									content: 'content 2',
+									placement: 'append',
+								},
+							},
+						],
+						config: {
+							declarationKind: 'interface',
+							onlyOperationTypes: true,
+							omitObjectTypes: true,
+							preResolveTypes: true,
+							option1: 'test',
+							option2: true,
+							option3: { test: 2 },
 						},
 					},
 				},


### PR DESCRIPTION
[SplitEnumsConfigurator] add plugin "@graphql-codegen/add"
[SplitEnumsConfigurator] change plugin typescript to graphql-codegen-typescript-operation-types (for remove unused input types)
[SplitEnumsConfigurator] fix pluginConfig type
[SplitEnumsPatcher] add noRootIndexFile for skip generation index file